### PR TITLE
Minor build tweaks

### DIFF
--- a/bundles/org.culturegraph.mf.ide.sdk/feature.xml
+++ b/bundles/org.culturegraph.mf.ide.sdk/feature.xml
@@ -6,11 +6,13 @@
 
    <includes
          id="org.eclipse.gef4.zest.sdk"
-         version="0.0.0"/>
+         version="0.0.0"
+         optional="true"/>
 
    <includes
          id="de.itemis.tooling.xturtle.feature"
-         version="0.0.0"/>
+         version="0.0.0"
+         optional="true"/>
 
    <plugin
          id="org.culturegraph.mf.ide"

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho-version>0.14.0</tycho-version>
+		<tycho-version>0.15.0</tycho-version>
 	</properties>
      <pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
- Build with Tycho 0.15 (includes version in p2 archive file name)
- Make Zest and Xturtle features optional to avoid unsuccessful
  installation when a different version of them is already installed
