### PR TITLE
Convert `\n` to `<br/>` in Flux command description metadata

### DIFF
--- a/bundles/org.culturegraph.mf.ide/src/org/culturegraph/mf/ide/domain/FluxCommandMetadata.java
+++ b/bundles/org.culturegraph.mf.ide/src/org/culturegraph/mf/ide/domain/FluxCommandMetadata.java
@@ -60,7 +60,8 @@ public class FluxCommandMetadata {
 									"<p><b>Out:</b> %s</p>" +
 									"<p><b>Implementation:</b> %s</p>" +
 							"</div>",
-							desc != null ? desc.value() : "<i>no description annotation</i>",
+							desc != null ? desc.value().replace("\n", "<br/>")
+									: "<i>no description annotation</i>",
 							in != null ? in.value() : "<i>no input annotation</i>",
 							out != null ? out.value() : "<i>no output annotation</i>",
 							impl.getName());


### PR DESCRIPTION
The Flux command metadata is used by the auto-suggest popup to show command details (descriptiopn, input, output). With this change, it is possible to display a formatted description, e.g. for a list of supported parameters. For that, the `@Description` of the command's implementation class needs to contain `\n` characters.

For a sample, see https://github.com/fsteeg/lodmill/commit/d24936ae2487ea77bd5f2e17959878c316fd088d

@dr0i @jschnasse I think this would be the most straightforward way to get the improved formatting in the IDE that we discussed earlier today. I think it makes sense to keep the HTML stuff contained in the IDE, and use `\n` characters in the `@Description`.
